### PR TITLE
Feat: remove home header buttons

### DIFF
--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -1,45 +1,23 @@
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import completedTasks from "../../assets/imagens/homePage/completed_tasks.svg";
 import completedTasksLitlle from "../../assets/imagens/homePage/completed_tasks_menor.svg";
 import homePageBanner from "../../assets/imagens/homePage/homePageBanner.svg";
 import Logo from "../../components/Logo";
-import MenuHeader from "../../components/MenuHeader";
 import ButtonDownloadApp from "../../components/buttons/ButtonApp";
-import ButtonPrincipal from "../../components/buttons/ButtonPrincipal";
-import ContainerIcons from "../../components/containers/ContainerIcons";
 import { ScrollToTop } from "../../utils/ScrollToTop";
 import * as S from "./styles";
 
 export default function HomePage() {
   const navigate = useNavigate();
-  const [isOpenMenu, setIsOpenMenu] = useState(false);
-
-  const menuItems = [
-    {
-      name: "Recursos",
-      url: "#",
-      id: 1,
-    },
-    {
-      name: "Planos",
-      url: "#",
-      id: 2,
-    },
-  ];
 
   return (
     <>
       <ScrollToTop />
       <S.Header>
         <Logo />
-        <S.ContainerButtonsHeader>
-          <ButtonPrincipal secondaryColor={true} onClick={() => navigate("/welcomePage")}>
+          <S.HomeButton secondaryColor={true} onClick={() => navigate("/welcomePage")}>
             Acesse
-          </ButtonPrincipal>
-          <ContainerIcons setIsShowMenu={setIsOpenMenu} />
-          {isOpenMenu && <MenuHeader setIsShowMenu={setIsOpenMenu} menuItems={menuItems} />}
-        </S.ContainerButtonsHeader>
+          </S.HomeButton>
       </S.Header>
 
       <S.Main>

--- a/src/pages/HomePage/index.tsx
+++ b/src/pages/HomePage/index.tsx
@@ -34,8 +34,6 @@ export default function HomePage() {
       <S.Header>
         <Logo />
         <S.ContainerButtonsHeader>
-          <ButtonPrincipal hover={false}>Recursos</ButtonPrincipal>
-          <ButtonPrincipal hover={false}>Planos</ButtonPrincipal>
           <ButtonPrincipal secondaryColor={true} onClick={() => navigate("/welcomePage")}>
             Acesse
           </ButtonPrincipal>

--- a/src/pages/HomePage/styles.tsx
+++ b/src/pages/HomePage/styles.tsx
@@ -32,7 +32,7 @@ export const ContainerButtonsHeader = styled.div`
   display: flex;
   align-items: center;
   max-width: 800px;
-  width: 100%;
+  width: min(100%, 160px);
   justify-content: space-between;
 
   ${Container} {
@@ -48,7 +48,7 @@ export const ContainerButtonsHeader = styled.div`
 
   ${media.desktop} {
     max-width: 408px;
-    width: 70%;
+    width: min(100%, 120px);
     gap: 24px;
   }
 

--- a/src/pages/HomePage/styles.tsx
+++ b/src/pages/HomePage/styles.tsx
@@ -3,6 +3,7 @@ import { Wrapper } from "../../components/MenuHeader/styles";
 import { Button as ButtonStyle } from "../../components/buttons/ButtonPrincipal/styles";
 import { Container } from "../../components/containers/ContainerIcons/styles";
 import media from "../../utils/functions/mediaQueries";
+import ButtonPrincipal from "../../components/buttons/ButtonPrincipal";
 
 export const Header = styled.header`
   display: flex;
@@ -25,6 +26,22 @@ export const Header = styled.header`
     & ${ButtonStyle} {
       margin-right: 8px;
     }
+  }
+`;
+
+export const HomeButton = styled(ButtonPrincipal)`
+  width: min(100%, 160px);
+
+  ${media.desktop} {
+    width: min(100%, 120px);
+  }
+
+  ${media.tablet} {
+    width: min(100%, 82px);
+  }
+
+  ${media.mobile} {
+    background: none;
   }
 `;
 
@@ -64,6 +81,10 @@ export const ContainerButtonsHeader = styled.div`
     & .resources,
     & .plans {
       display: none;
+    }
+
+    ${"ButtonPrincipal"} {
+      background-color: crimson;
     }
   }
 `;


### PR DESCRIPTION
Os botões foram removidos, porém a tarefa carece de certas informações. Quando a tela chega no mobile, um hamburger menu aparece se os botões a remover não existirem e fica o botão de acesse ao lado desse hamburger, o que passa uma sensação de não estar certo.

 Me faltou um pouco de certeza quanto aos designs que representam as atuais telas, o que não me permitiu discernir o que seria de fato a abordagem correta, então este ponto está em aberto.