### PR TITLE
feat: change checkbox style when selected

### DIFF
--- a/src/components/Input/styles.tsx
+++ b/src/components/Input/styles.tsx
@@ -56,23 +56,30 @@ export const InputStyle = styled.input<InputProps>`
   color: ${({ $hasErro }) => ($hasErro ? "#B3261b" : "#333333")};
   resize: none;
 
+  &:focus {
+    border: 1px solid ${({ $hasErro }) => ($hasErro ? "#B3261b" : "#5c59bb")};
+  }
+
   &:focus ~ ${LabelInput} {
     top: -15px;
     font-size: 0.85rem;
     background-color: transparent;
     padding: 0.2rem;
     transition: all 0.4s ease;
+    color: ${({ $hasErro }) => ($hasErro ? "#B3261b" : "#5c59bb")} !important;
   }
 
   &::placeholder {
     color: transparent;
   }
+
   &:not(:placeholder-shown) ~ ${LabelInput} {
     top: -15px;
     font-size: 0.85rem;
     padding: 0.2rem;
     color: ${({ $hasErro }) => ($hasErro ? "#B3261b" : "#333333")};
   }
+
   &::-ms-reveal,
   ::-ms-clear {
     display: none;


### PR DESCRIPTION
Ajuste no estilo visual do checkbox na tela de criação de conta.
Agora, quando o checkbox está selecionado/preenchido, ele exibe corretamente o estilo correspondente ao estado ativo, garantindo consistência com o design system e melhorando a experiência do usuário.